### PR TITLE
Issue 3 - Force async calls to throw on failure

### DIFF
--- a/src/functions/Connect-Okta.ps1
+++ b/src/functions/Connect-Okta.ps1
@@ -29,6 +29,9 @@ function Connect-Okta
     }
     catch
     {
-        $PSCmdlet.ThrowTerminatingError($_)
+        throw [System.ArgumentException]::new(
+            'Failed to connect to your Okta org with the parameters provided.',
+            $_.Exception
+        )
     }
 }

--- a/src/functions/Connect-Okta.ps1
+++ b/src/functions/Connect-Okta.ps1
@@ -15,10 +15,13 @@ function Connect-Okta
         $ApiToken
     )
     
-    $Configuration = [Okta.Sdk.Configuration.OktaClientConfiguration]::new()
-    $Configuration.OktaDomain = $OktaDomain
-    $Configuration.Token = $ApiToken
-    $Client = [Okta.Sdk.OktaClient]::new($Configuration)
+    
+    $Client = [Okta.Sdk.OktaClient]::new(
+        [Okta.Sdk.Configuration.OktaClientConfiguration]@{
+            OktaDomain = $OktaDomain
+            Token      = $ApiToken
+        }
+    )
     
     try
     {

--- a/src/helpers/Get-CurrentUser.ps1
+++ b/src/helpers/Get-CurrentUser.ps1
@@ -8,6 +8,7 @@ function Get-CurrentUser
         [Okta.Sdk.OktaClient]
         $Client
     )
-
-    [Okta.PS.User]::new([Okta.PS.User]::GetCurrentUser($Client).Result)
+    
+    $Result = Wait-Task -Task ([Okta.PS.User]::GetCurrentUser($Client)) -ErrorAction Stop
+    [Okta.PS.User]::new($Result)       
 }

--- a/src/helpers/Wait-Task.ps1
+++ b/src/helpers/Wait-Task.ps1
@@ -1,0 +1,20 @@
+function Wait-Task
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory)]
+        [System.Threading.Tasks.Task]
+        $Task
+    )
+
+    try
+    {
+        $Task.Wait()
+        $Task.Result
+    }
+    catch
+    {
+        throw $Task.Exception.InnerException
+    }
+}


### PR DESCRIPTION
These changes will ensure that failures of any of the async method calls from the Okta SDK are treated as stop errors. Specifically it implements a `Wait-Task` command that can be used in any module command to get the results or the exception from an async task. This can then be rethrown with added context based on which command was the caller.