### PR TITLE
Improve testability with helper functions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,6 @@ jobs:
 
 - job: windows
   dependsOn: xplat
-  condition: succeeded()
   
   pool:
     vmImage: 'windows-2019'

--- a/src/functions/Get-OktaConnection.ps1
+++ b/src/functions/Get-OktaConnection.ps1
@@ -2,13 +2,20 @@ function Get-OktaConnection
 {
     [CmdletBinding()]
     [OutputType([Okta.Sdk.Configuration.OktaClientConfiguration])]
-    param
-    (
+    param ()
 
-    )
+    try
+    {
+        Test-OktaConnection
 
-    $Configuration = [Okta.Sdk.Configuration.OktaClientConfiguration]::new()
-    $Configuration.OktaDomain = $Script:ModuleClient.Configuration.OktaDomain
-    $Configuration.Token = Get-ObscureToken -Token $Script:ModuleClient.Configuration.Token -VisibleLength 8
-    $Configuration
+        $Configuration = [Okta.Sdk.Configuration.OktaClientConfiguration]::new()
+        $Configuration.OktaDomain = $Script:ModuleClient.Configuration.OktaDomain
+        $Configuration.Token = Get-ObscureToken -Token $Script:ModuleClient.Configuration.Token -VisibleLength 8
+        $Configuration
+    }
+    catch
+    {
+        $PSCmdlet.ThrowTerminatingError($_)
+    }
+    
 }

--- a/src/functions/Get-OktaUser.ps1
+++ b/src/functions/Get-OktaUser.ps1
@@ -19,21 +19,24 @@ function Get-OktaUser
     
     try
     {
+        Test-OktaConnection
+        $Type = $PSCmdlet.MyInvocation.MyCommand.OutputType.Type
+        
         $Task = switch ($PSCmdlet.ParameterSetName)
         {
             "Identity"
             {
-                [Okta.PS.User]::GetUser($Script:Moduleclient, $Identity)
+                Invoke-Method -Type $Type -MethodName "GetUser" -Arguments @($Script:ModuleClient, $Identity)
             }
 
             "Filter"
             {
-                [Okta.PS.User]::FilterUsers($Script:Moduleclient, $Filter)
+                Invoke-Method -Type $Type -MethodName "FilterUsers" -Arguments @($Script:ModuleClient, $Filter)
             }
 
             "All"
             {
-                [Okta.PS.User]::GetAllUsers($Script:Moduleclient)
+                Invoke-Method -Type $Type -MethodName "GetAllUsers" -Arguments @($Script:ModuleClient)
             }
         }
 
@@ -41,7 +44,7 @@ function Get-OktaUser
 
         foreach ($Item in $Result)
         {
-            [Okta.PS.User]::new($Item)
+            $Type::new($Item)
         }
     }
     catch

--- a/src/functions/Get-OktaUser.ps1
+++ b/src/functions/Get-OktaUser.ps1
@@ -4,7 +4,7 @@ function Get-OktaUser
     [OutputType([Okta.PS.User])]
     param
     (
-        [Parameter(Mandatory, ParameterSetName = "Identity")]
+        [Parameter(Mandatory, ParameterSetName = "Identity", Position = 0)]
         [string]
         $Identity,
 

--- a/src/helpers/Invoke-Method.ps1
+++ b/src/helpers/Invoke-Method.ps1
@@ -1,0 +1,21 @@
+function Invoke-Method
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory)]
+        [System.Type]
+        $Type,
+
+        [Parameter(Mandatory)]
+        [string]
+        $MethodName,
+
+        [object[]]
+        $Arguments
+    )
+    
+    $BindingFlags = [Reflection.BindingFlags] "Public,Static"
+    $Method = $Type.GetMethod($MethodName, $BindingFlags)
+    $Method.Invoke($null, $Arguments)
+}

--- a/src/helpers/Test-OktaConnection.ps1
+++ b/src/helpers/Test-OktaConnection.ps1
@@ -1,0 +1,14 @@
+function Test-OktaConnection
+{
+    [CmdletBinding()]
+    param ()
+    
+    if (!$Script:ModuleClient)
+    {
+        $PSCmdlet.ThrowTerminatingError(
+            [System.UnauthorizedAccessException]::new(
+                "No connection to an Okta org was found. Did you run 'Connect-Okta' first?"
+            )
+        )
+    }
+}

--- a/src/helpers/Test-OktaConnection.ps1
+++ b/src/helpers/Test-OktaConnection.ps1
@@ -5,10 +5,8 @@ function Test-OktaConnection
     
     if (!$Script:ModuleClient)
     {
-        $PSCmdlet.ThrowTerminatingError(
-            [System.UnauthorizedAccessException]::new(
-                "No connection to an Okta org was found. Did you run 'Connect-Okta' first?"
-            )
+        throw [System.UnauthorizedAccessException]::new(
+            "No connection to an Okta org was found. Did you run 'Connect-Okta' first?"
         )
     }
 }

--- a/tests/Get-OktaUser.tests.ps1
+++ b/tests/Get-OktaUser.tests.ps1
@@ -12,13 +12,6 @@ Import-Module $ModulePath -Force
 
         # tests where an API connection is not needed
         Context "No Connection" {
-            #Mock Wait-Task { New-MockObject -Type Okta.Sdk.User } @Splat_ModuleName
-            #Mock Invoke-Method { New-MockObject System.Threading.Tasks.Task } @Splat_ModuleName
-            
-            It "-Identity is positional" {
-                { Get-OktaUser "nuffin" } | Should Not Throw "A positional parameter cannot be found that accepts argument"
-            }
-
             It "enforces exclusive parameters" {
                 { Get-OktaUser -Identity "nuffin" -Filter 'status eq "STAGED"' } | Should Throw "Parameter set cannot be resolved"
             }
@@ -31,11 +24,13 @@ Import-Module $ModulePath -Force
         # tests that require a connection object to succeed
         Context "Connection" {
             Mock Test-OktaConnection { } @Splat_ModuleName
-            #Mock Wait-Task { New-MockObject -Type Okta.Sdk.User } @Splat_ModuleName
-            #Mock Invoke-Method { New-MockObject System.Threading.Tasks.Task } @Splat_ModuleName
             
             It "outputs a User object" {
                 Get-OktaUser -Identity "nuffin" | Should BeOfType [Okta.PS.User]
+            }
+
+            It "-Identity is positional" {
+                { Get-OktaUser "nuffin" } | Should Not Throw
             }
         }
 

--- a/tests/Get-OktaUser.tests.ps1
+++ b/tests/Get-OktaUser.tests.ps1
@@ -5,8 +5,57 @@ param
 
 Import-Module $ModulePath -Force
 
-InModuleScope "Okta" {
     Describe "Get-OktaUser" {
+        $Splat_ModuleName = @{ModuleName = "Okta"}
+        Mock Wait-Task { New-MockObject -Type Okta.Sdk.User } @Splat_ModuleName
+        Mock Invoke-Method { New-MockObject System.Threading.Tasks.Task } @Splat_ModuleName
 
+        # tests where an API connection is not needed
+        Context "No Connection" {
+            #Mock Wait-Task { New-MockObject -Type Okta.Sdk.User } @Splat_ModuleName
+            #Mock Invoke-Method { New-MockObject System.Threading.Tasks.Task } @Splat_ModuleName
+            
+            It "-Identity is positional" {
+                { Get-OktaUser "nuffin" } | Should Not Throw "A positional parameter cannot be found that accepts argument"
+            }
+
+            It "enforces exclusive parameters" {
+                { Get-OktaUser -Identity "nuffin" -Filter 'status eq "STAGED"' } | Should Throw "Parameter set cannot be resolved"
+            }
+
+            It "throws connection error" {
+                { Get-OktaUser -Identity "nuffin" } | Should Throw "No connection to an Okta org was found. Did you run 'Connect-Okta' first?"
+            }
+        }
+
+        # tests that require a connection object to succeed
+        Context "Connection" {
+            Mock Test-OktaConnection { } @Splat_ModuleName
+            #Mock Wait-Task { New-MockObject -Type Okta.Sdk.User } @Splat_ModuleName
+            #Mock Invoke-Method { New-MockObject System.Threading.Tasks.Task } @Splat_ModuleName
+            
+            It "outputs a User object" {
+                Get-OktaUser -Identity "nuffin" | Should BeOfType [Okta.PS.User]
+            }
+        }
+
+        Context "Methods" {
+            Mock Test-OktaConnection { } @Splat_ModuleName
+            $GetUser = { $MethodName -eq "GetUser" }
+            $FilterUsers = { $MethodName -eq "FilterUsers" }
+            $GetAllUsers = { $MethodName -eq "GetAllUsers" }
+            Mock Invoke-Method { New-MockObject System.Threading.Tasks.Task } -ParameterFilter $GetUser -Verifiable  @Splat_ModuleName
+            Mock Invoke-Method { New-MockObject System.Threading.Tasks.Task } -ParameterFilter $FilterUsers -Verifiable @Splat_ModuleName
+            Mock Invoke-Method { New-MockObject System.Threading.Tasks.Task } -ParameterFilter $GetAllUsers -Verifiable @Splat_ModuleName
+            Mock Wait-Task { New-MockObject -Type Okta.Sdk.User } @Splat_ModuleName
+            $null = Get-OktaUser -Identity "willard.hunter@example.com"
+            $null = Get-OktaUser -Filter 'profile.lastName eq "hunter"'
+            $null = Get-OktaUser -All
+                    
+            It "invokes correct method" {
+                Assert-MockCalled -CommandName Invoke-Method -ParameterFilter $GetUser -Times 1 @Splat_ModuleName
+                Assert-MockCalled -CommandName Invoke-Method -ParameterFilter $FilterUsers -Times 1 @Splat_ModuleName
+                Assert-MockCalled -CommandName Invoke-Method -ParameterFilter $GetAllUsers -Times 1 @Splat_ModuleName
+            }
+        }
     }
-}


### PR DESCRIPTION
This PR introduces several changes to improve the testability of Okta commands. The `Get-OktaUser` command specifically has two problems:

1. It doesn't check for an active client object before executing. The error that is returned if a client doesn't exist is not helpful. `Test-Okta-Connection` provides a way to check this prior to executing and throw a useful error, and also provides a mocking point for tests.

2. Calling .Net methods directly to query for users is inherently not testable since there is no way to mock the calls with Pester. `Invoke-Method` replaces the .Net calls with a mockable function.

These patterns can be reused with any functions that are added in the future.